### PR TITLE
Correct various documentation typos

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -5,7 +5,7 @@ The ``pygcam`` scripts and libraries rely on a configuration file to:
 
   * define the location of essential and optional files,
   * allow the user to set defaults for many command-line arguments to scripts, and
-  * define both global default and project-specific values for all parameters
+  * define both global default and project-specific values for all parameters.
 
 The configuration file and variables are described below.
 
@@ -39,7 +39,7 @@ Project sections
 ^^^^^^^^^^^^^^^^^^^^^^
 Each project must have its own section. For example, to setup a project called,
 say, "myproj", I would create the section ``[myproj]``. Following this, I would define
-variables particular to this project, e.g., where the to find the files defining scenarios,
+variables particular to this project, e.g., where to find the files defining scenarios,
 queries, and so on.
 
 Note that the :ref:`new <new>` sub-command will set up the structure for a new

--- a/docs/source/initialize.rst
+++ b/docs/source/initialize.rst
@@ -5,7 +5,7 @@ The :ref:`init <init>` sub-command creates the configuration file
 ``~/.pygcam.cfg`` and initializes key variables, based on command-line
 arguments (if provided) or interactive prompts. The :ref:`init <init>`
 sub-command must be run before any other :doc:`gcamtool` command can
-be run (with the exception of displaying command-line help.)
+be run (with the exception of displaying command-line help).
 
 The information required to initialize your config file includes:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -214,10 +214,10 @@ Enable symbolic links
 
 In Unix-like systems, "symbolic links" (symlinks) are frequently used to provide shortcuts
 or aliases to files and directories. The pygcam scripts use symlinks to create GCAM workspaces
-without having to lots of large, read-only files. Rather, it creates workspaces with writable
+without having to make copies of lots of large, read-only files. Rather, it creates workspaces with writable
 directories where GCAM will create files at run-time, and it uses symlinks to the read-only
 files (e.g., the GCAM executable) and folders (e.g., the ``input`` directory holding GCAM's
-XML input files.
+XML input files).
 
 Windows (Vista and onward) also have symlinks, but only administrators can create symlinks
 **unless specific permission has been granted** to a user. To grant this permission, run the
@@ -232,7 +232,7 @@ account is in.)
   .. image:: images/symlinkPermission.jpg
 
 Also, note the following:
-  - To remove a symlink to a file, use the ``del`` command
+  - To remove a symlink to a file, use the ``del`` command.
   - To remove a symlink to a folder, use ``rmdir`` (or ``rd`` for short).
 
     **Using "del" on a symlink to a folder will offer to delete not just symlink,
@@ -242,7 +242,7 @@ Also, note the following:
 
   - Either type of symlink can be removed using the file Explorer as well.
 
-  - Symlinks work across devices and network, and through other symlinks, however, if you
+  - Symlinks work across devices and network, and through other symlinks. However, if you
     are working across multiple drives, be sure that you specify the drive letter (e.g., ``C:``)
     in the link target or the path will be interpreted relative to the current drive.
 
@@ -312,7 +312,7 @@ Installing GCAM and Java
 ---------------------------
 
 Regardless of how you've installed ``pygcam``, you will also need to install GCAM itself,
-which in turn requires java.
+which in turn requires Java.
 
 This is a short guide to these topics since they are outside the scope of ``pygcam``.
 See the `GCAM <https://github.com/JGCRI/gcam-core/releases>`_ website for the most

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -58,8 +58,8 @@ Project file
 .. _query-def:
 
 Query definitions
-  A list of XML queries used to extract date from the GCAM database into CSV
-  files. Query definitions can be simply references to queries by name, or they
+  A list of XML queries used to extract data from the GCAM database into CSV
+  files. Query definitions can simply be references to queries by name, or they
   can include references to :ref:`rewrite sets <rewrite-sets-def>` to cause
   rewrites to be added to the XML query on-the-fly. See also: :doc:`query-xml`.
 

--- a/docs/source/tutorial1.rst
+++ b/docs/source/tutorial1.rst
@@ -218,7 +218,7 @@ project steps::
 1.2 The scenarios.xml file
 ---------------------------
 The following :doc:`scenarios-xml` file is also included automatically when you run the
-:ref:`init <init>` or :ref:`new <new>` sub-commands. It defined one scenario group
+:ref:`init <init>` or :ref:`new <new>` sub-commands. It defines one scenario group
 consisting of a baseline and 4 carbon tax policy scenarios:
 
 .. literalinclude:: ../../pygcam/etc/examples/scenarios.xml
@@ -375,7 +375,7 @@ The following is equivalent to our "cut & paste" example above:
 
 The example above defines an iterator named "tax", with values 10, 15, 20, and 25.
 The scenario group includes the same baseline as before, but now there are just two
-``<scenario>`` definition, one for fossil carbon and one for fossil and biogenic
+``<scenario>`` definitions, one for fossil carbon and one for fossil and biogenic
 carbon. The term ``{tax}`` is replaced by each value of the iterator in turn,
 defining a new scenario, and indicating which file to include in the ``<add>``
 element. Thus, by iterating over the tax levels, we have created 9 scenarios: one

--- a/docs/source/tutorial2.rst
+++ b/docs/source/tutorial2.rst
@@ -75,7 +75,7 @@ Let's start by running just the ``tax-10`` scenario::
 
     $ gt run -S tax-10
 
-Again, we wait while ``gt`` runs gcam, runs the defined queries to create CSV files.
+Again, we wait while ``gt`` runs gcam and runs the defined queries to create CSV files.
 Because this is a policy scenario, we will also compute the differences between
 query results for "policy minus baseline", and save these in the ``diffs`` directory
 in the scenario's sandbox. Our project file also generates a few plots to look at,

--- a/docs/source/tutorial3.rst
+++ b/docs/source/tutorial3.rst
@@ -3,8 +3,8 @@ Tutorial, Part 3
 
 Here, in Part 3, we will customize the project to:
 
- * modify chart appearance
- * add another query and plot the results
+ * modify chart appearance,
+ * add another query and plot the results, and
  * aggregate regions to simplify plot appearance.
 
 3.0 The ``chart`` sub-command


### PR DESCRIPTION
I noticed various small typos in the (first half of) the documentation pages, and thought I'd suggest clarifying edits.